### PR TITLE
Changes to table creation & boolean handling

### DIFF
--- a/bin/create_master
+++ b/bin/create_master
@@ -9,6 +9,7 @@ opts = OptionParser.new do |o|
   o.on('-d', '--dry-run') {dry_run = true}
 end
 
+opts.parse!
 
 conn = PostgresToRedshift.new(dbname: nil, dry_run: dry_run)
 conn.update_tables

--- a/bin/create_master
+++ b/bin/create_master
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 require 'bundler/setup'
+require 'optparse'
 require_relative '../lib/postgres_to_redshift'
 
-conn = PostgresToRedshift.new(dbname: nil)
+dry_run = false
+
+opts = OptionParser.new do |o|
+  o.on('-d', '--dry-run') {dry_run = true}
+end
+
+
+conn = PostgresToRedshift.new(dbname: nil, dry_run: dry_run)
 conn.update_tables

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -143,6 +143,7 @@ class PostgresToRedshift
     source_connection.exec(table_select_sql(schema: schema)).map do |table_attributes|
       table = Table.new(attributes: table_attributes)
       next if table.name =~ /^pg_/
+      next if table.name =~ /^temp_/
       table.columns = column_definitions(table: table, schema: schema)
       table
     end.compact

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -29,11 +29,12 @@ class PostgresToRedshift
       target_connection.exec("CREATE SCHEMA IF NOT EXISTS #{schema}") unless schema_exist? schema
 
       tables(schema: schema).each do |table|
+
         ddl = 'CREATE TABLE IF NOT EXISTS '
         ddl << "#{schema}.#{target_connection.quote_ident(table.target_table_name)} "
         ddl << '('
         ddl << "#{table.columns_for_create}"
-        ddl << ", primary key(#{table.primary_key.map {|name| %Q["#{name}"]}.join(', ')})" if table.primary_key && !table.primary_key.empty?
+        ddl << ", primary key(#{table.primary_key_columns.map {|name| %Q["#{name}"]}.join(', ')})" if table.primary_key && table.primary_key_columns.any?
         ddl << ')'
         target_connection.exec(ddl)
       end

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -83,8 +83,12 @@ class PostgresToRedshift::Column
     when 'character varying'
       #postgres counts in characters but redshift counts in bytes
       #so we need to multiply by 4 (the maximum character length supported)
-      postgres_limit = (attributes['character_maximum_length'] || 256).to_i
-      redshift_limit = postgres_limit * 4
+
+      postgres_limit = attributes['character_maximum_length']&.to_i
+      #in the postgres world no limit means that - no limit
+      #but in the postgres world, that means max of 256 (bytes)
+      #so we convert that to the biggest redshift supports
+      redshift_limit = postgres_limit ? [postgres_limit * 4, 65535].min : 'MAX'
       "character varying(#{redshift_limit})"
     else
       CAST_TYPES_FOR_COPY[data_type] || data_type

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -56,6 +56,7 @@ class PostgresToRedshift::Column
     'uuid' => "CHAR(36)",
     "ARRAY" => "CHARACTER VARYING(65535)",
     "USER-DEFINED" => "CHARACTER VARYING(65535)",
+    "boolean" => "smallint"
   }
 
   def initialize(attributes: )
@@ -82,6 +83,10 @@ class PostgresToRedshift::Column
     if attributes["is_nullable"] == 'NO'
       " NOT NULL"
     end
+  end
+
+  def skip?
+    name =~ /_shadow_/
   end
 
   def data_type_for_copy

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -78,6 +78,12 @@ class PostgresToRedshift::Column
     attributes["data_type"]
   end
 
+  def null_constraint
+    if attributes["is_nullable"] == 'NO'
+      " NOT NULL"
+    end
+  end
+
   def data_type_for_copy
     case data_type
     when 'character varying'

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -86,7 +86,7 @@ class PostgresToRedshift::Column
   end
 
   def skip?
-    name =~ /_shadow_/
+    name =~ /_shadow_/ || name =~ /_replication_/
   end
 
   def data_type_for_copy

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -79,7 +79,16 @@ class PostgresToRedshift::Column
   end
 
   def data_type_for_copy
-    CAST_TYPES_FOR_COPY[data_type] || data_type
+    case data_type
+    when 'character varying'
+      #postgres counts in characters but redshift counts in bytes
+      #so we need to multiply by 4 (the maximum character length supported)
+      postgres_limit = (attributes['character_maximum_length'] || 256).to_i
+      redshift_limit = postgres_limit * 4
+      "character_varying (#{redshift_limit})"
+    else
+      CAST_TYPES_FOR_COPY[data_type] || data_type
+    end
   end
 
   private

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -85,7 +85,7 @@ class PostgresToRedshift::Column
       #so we need to multiply by 4 (the maximum character length supported)
       postgres_limit = (attributes['character_maximum_length'] || 256).to_i
       redshift_limit = postgres_limit * 4
-      "character_varying (#{redshift_limit})"
+      "character varying(#{redshift_limit})"
     else
       CAST_TYPES_FOR_COPY[data_type] || data_type
     end

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -17,7 +17,7 @@ class PostgresToRedshift
 
     def initialize(attributes: , columns: [])
       self.attributes = attributes
-      self.columns = columns.reject {|column| column.skip?}
+      self.columns = columns
     end
 
     def name
@@ -33,7 +33,7 @@ class PostgresToRedshift
     def columns=(column_definitions = [])
       @columns = column_definitions.map do |column_definition|
         Column.new(attributes: column_definition)
-      end
+      end.reject {|column| column.skip?}
     end
 
     def columns_for_create

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -38,7 +38,7 @@ class PostgresToRedshift
 
     def columns_for_create
       columns.map do |column|
-        %Q["#{column.name}" #{column.data_type_for_copy}]
+        %Q["#{column.name}" #{column.data_type_for_copy}#{column.null_constraint}]
       end.join(", ")
     end
 

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -52,8 +52,23 @@ class PostgresToRedshift
       attributes['primary_key']
     end
 
+    def primary_key_columns
+      parse_array(attributes['primary_key'])
+    end
+
     def is_view?
       attributes["table_type"] == "VIEW"
+    end
+
+    private
+
+    def parse_array string
+      #this is very naive and doesn't try to handle the complicated cases
+      #because our table names don't contain values such as space or comma
+
+      string.split(',').map do |candidate|
+        candidate.gsub(/[{}"]/, '')
+      end
     end
   end
 end

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -17,7 +17,7 @@ class PostgresToRedshift
 
     def initialize(attributes: , columns: [])
       self.attributes = attributes
-      self.columns = columns
+      self.columns = columns.reject {|column| column.skip?}
     end
 
     def name


### PR DESCRIPTION
These are some changes I've made while setting up replication:

- multicolumn primary keys (previously it was creating primary key on one of the columns only)
- not null constraints were not being preserved
- character varying lengths were wrong in two ways:
redshift counts bytes, but postgres counts characters, so limit on redshift needs to be higher
on postgres character varying with no limit means unlimited, but on redshift this means default limit of 256
- handling of boolean columns as discussed
- don't recreate any tables with the temp prefix